### PR TITLE
Remove trailing comma from JSON object literal.

### DIFF
--- a/presentation.slide
+++ b/presentation.slide
@@ -150,7 +150,7 @@ The new `go`env`-json` flag enables JSON output, instead of the default OS-speci
         "GOOS": "linux",
         "GOPATH": "/home/dfc",
         "GOROOT": "/home/dfc/go",
-        "GOTOOLDIR": "/home/dfc/go/pkg/tool/linux_amd64",
+        "GOTOOLDIR": "/home/dfc/go/pkg/tool/linux_amd64"
  } 
 
 * go test -list 


### PR DESCRIPTION
A trailing comma isn't permitted by the spec (json.org).

The `go env -json` behaviour is correct; it's only a typo on this slide.